### PR TITLE
Ensure safe callback cleanup when dropping IndexReader

### DIFF
--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -223,6 +223,10 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// `OnCommitWithDelay` `ReloadPolicy`. Not implementing watch in a `Directory` only prevents
     /// the `OnCommitWithDelay` `ReloadPolicy` to work properly.
     fn watch(&self, watch_callback: WatchCallback) -> crate::Result<WatchHandle>;
+
+    /// Stops the watcher and clears all registered callbacks.
+    /// The behavior of subsequent calls to `watch()` depends on the specific Directory implementation.
+    fn unwatch_callbacks(&self);
 }
 
 /// DirectoryClone
@@ -232,7 +236,8 @@ pub trait DirectoryClone {
 }
 
 impl<T> DirectoryClone for T
-where T: 'static + Directory + Clone
+where
+    T: 'static + Directory + Clone,
 {
     fn box_clone(&self) -> Box<dyn Directory> {
         Box::new(self.clone())

--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -225,7 +225,8 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     fn watch(&self, watch_callback: WatchCallback) -> crate::Result<WatchHandle>;
 
     /// Stops the watcher and clears all registered callbacks.
-    /// The behavior of subsequent calls to `watch()` depends on the specific Directory implementation.
+    /// The behavior of subsequent calls to `watch()` depends on the specific Directory
+    /// implementation.
     fn unwatch_callbacks(&self);
 }
 
@@ -236,8 +237,7 @@ pub trait DirectoryClone {
 }
 
 impl<T> DirectoryClone for T
-where
-    T: 'static + Directory + Clone,
+where T: 'static + Directory + Clone
 {
     fn box_clone(&self) -> Box<dyn Directory> {
         Box::new(self.clone())

--- a/src/directory/file_watcher.rs
+++ b/src/directory/file_watcher.rs
@@ -197,32 +197,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[test]
-    fn test_file_watcher_drop_handle_and_watcher() -> crate::Result<()> {
-        let tmp_dir = tempfile::TempDir::new()?;
-        let tmp_file = tmp_dir.path().join("watched.txt");
-
-        let watcher = FileWatcher::new(&tmp_file);
-
-        let (tx, rx) = std::sync::mpsc::channel();
-        let handle = watcher.watch(WatchCallback::new(move || {
-            assert!(tx.send(()).is_ok());
-            thread::sleep(Duration::from_secs(3));
-            assert!(tx.send(()).is_ok());
-        }));
-
-        // change the file
-        atomic_write(&tmp_file, b"foo")?;
-
-        // wait for the callback to be called
-        let timeout = Duration::from_secs(3);
-        assert!(rx.recv_timeout(timeout).is_ok());
-
-        mem::drop(watcher);
-        // check that the callback finished
-        assert!(rx.try_recv().is_ok());
-
-        Ok(())
-    }
 }

--- a/src/directory/file_watcher.rs
+++ b/src/directory/file_watcher.rs
@@ -111,6 +111,12 @@ impl FileWatcher {
     }
 }
 
+impl Drop for FileWatcher {
+    fn drop(&mut self) {
+        self.graceful_stop();
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/src/directory/file_watcher.rs
+++ b/src/directory/file_watcher.rs
@@ -98,10 +98,8 @@ impl FileWatcher {
 
         Ok(hasher.finalize())
     }
-}
 
-impl Drop for FileWatcher {
-    fn drop(&mut self) {
+    pub fn graceful_stop(&self) {
         self.state.store(2, Ordering::SeqCst);
         if let Some(handle) = self.watch_handle.write().unwrap().take() {
             let _ = self.wakeup_channel.write().unwrap().take();

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -319,6 +319,10 @@ impl Directory for ManagedDirectory {
         self.directory.watch(watch_callback)
     }
 
+    fn unwatch_callbacks(&self) {
+        self.directory.unwatch_callbacks();
+    }
+
     fn sync_directory(&self) -> io::Result<()> {
         self.directory.sync_directory()?;
         Ok(())

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -498,6 +498,10 @@ impl Directory for MmapDirectory {
         Ok(self.inner.watch(watch_callback))
     }
 
+    fn unwatch_callbacks(&self) {
+        self.inner.watcher.graceful_stop();
+    }
+
     #[cfg(windows)]
     fn sync_directory(&self) -> Result<(), io::Error> {
         // On Windows, it is not necessary to fsync the parent directory to

--- a/src/directory/ram_directory.rs
+++ b/src/directory/ram_directory.rs
@@ -234,6 +234,10 @@ impl Directory for RamDirectory {
         Ok(self.fs.write().unwrap().watch(watch_callback))
     }
 
+    fn unwatch_callbacks(&self) {
+        self.fs.write().unwrap().watch_router.clear();
+    }
+
     fn sync_directory(&self) -> io::Result<()> {
         Ok(())
     }

--- a/src/directory/watch_event_router.rs
+++ b/src/directory/watch_event_router.rs
@@ -26,6 +26,12 @@ pub struct WatchCallbackList {
     router: RwLock<Vec<Weak<WatchCallback>>>,
 }
 
+impl WatchCallbackList {
+    pub fn clear(&self) {
+        self.router.write().unwrap().clear();
+    }
+}
+
 /// Controls how long a directory should watch for a file change.
 ///
 /// After all the clones of `WatchHandle` are dropped, the associated will not be called when a

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -305,40 +305,8 @@ impl IndexReader {
 
 impl Drop for IndexReader {
     fn drop(&mut self) {
-        // For mmap directory, unwatch_callbacks() will block until running callbacks are finished to ensure
-        // no lock file will be created after the index reader is dropped.
+        // For mmap directory, unwatch_callbacks() will block until running callbacks are finished
+        // to ensure no lock file will be created after the index reader is dropped.
         self.inner.index.directory().unwatch_callbacks();
-    }
-}
-
-mod tests {
-    use std::{thread::sleep, time::Duration};
-
-    use crate::{
-        directory::MmapDirectory,
-        schema::{Schema, INDEXED},
-    };
-
-    use super::*;
-
-    #[test]
-    fn test_callback_completes_after_index_reader_drop() {
-        let mut schema_builder = Schema::builder();
-        schema_builder.add_u64_field("num_likes", INDEXED);
-        let schema = schema_builder.build();
-        let index = Index::create_from_tempdir(schema).unwrap();
-        let index_reader = IndexReaderBuilder::new(index).try_into().unwrap();
-
-        let (tx_start, rx_start) = std::sync::mpsc::channel::<()>();
-        let (tx_end, rx_end) = std::sync::mpsc::channel::<()>();
-        let callback = WatchCallback::new(move || {
-            tx_start.send(()).unwrap();
-            sleep(Duration::from_secs(3));
-            tx_end.send(()).unwrap();
-        });
-        let _watch_handle = index_reader.inner.index.directory().watch(callback);
-        rx_start.recv().unwrap();
-        drop(index_reader);
-        assert!(rx_end.try_recv().is_ok());
     }
 }


### PR DESCRIPTION
### Issue
After the IndexReader is dropped, the FileWatcher may continue running. This can lead to lock files being generated in the directory, which may cause Milvus to fail when attempting to delete the directory

### Solution
Ensure FileWatcher stops running when IndexReader is dropped, preventing unnecessary lock file creation and avoiding deletion errors.

