### PR TITLE
enhance: eliminating dedicated threads by using tokio runtime further

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ time = { version = "0.3.10", features = ["serde-well-known", "macros"] }
 postcard = { version = "1.0.4", features = [
   "use-std",
 ], default-features = false }
+tokio = { version = "1.29.1", features = ["rt-multi-thread", "macros"] }
 
 [target.'cfg(not(windows))'.dev-dependencies]
 criterion = { version = "0.5", default-features = false }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,6 +17,7 @@ ownedbytes = { version= "0.7", path="../ownedbytes" }
 async-trait = "0.1"
 time = { version = "0.3.10", features = ["serde-well-known"] }
 serde = { version = "1.0.136", features = ["derive"] }
+tokio = { version = "1.29.1", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 binggan = "0.14.0"

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -37,6 +37,7 @@ pub use self::merge_operation::MergeOperation;
 pub use self::merge_policy::{MergeCandidate, MergePolicy, NoMergePolicy};
 use self::operation::AddOperation;
 pub use self::operation::UserOperation;
+pub use self::pool::TOKIO_DOCSTORE_COMPRESS_RUNTIME;
 pub use self::prepared_commit::PreparedCommit;
 pub use self::segment_entry::SegmentEntry;
 pub use self::segment_serializer::SegmentSerializer;

--- a/src/indexer/pool.rs
+++ b/src/indexer/pool.rs
@@ -3,9 +3,11 @@ use rayon::{ThreadPool, ThreadPoolBuilder};
 use std::str::FromStr;
 use std::{env, thread};
 
-const MILVUS_TANTIVY_MERGER_THREAD_NUM: &str = "MILVUS_TANTIVY_MERGER_THREAD_NUM";
+const MILVUS_TOKIO_MERGER_THREAD_NUM: &str = "MILVUS_TANTIVY_MERGER_THREAD_NUM";
 const MILVUS_TANTIVY_WRITER_THREAD_NUM: &str = "MILVUS_TANTIVY_WRITER_THREAD_NUM";
 const MILVUS_TOKIO_THREAD_NUM: &str = "MILVUS_TOKIO_THREAD_NUM";
+const MILVUS_TOKIO_DOCSTORE_COMPRESS_THREAD_NUM: &str =
+    "MILVUS_TANTIVY_DOCSTORE_COMPRESS_THREAD_NUM";
 
 lazy_static! {
     pub static ref TOKIO_RUNTIME: tokio::runtime::Runtime =
@@ -19,11 +21,19 @@ lazy_static! {
         .thread_name(|sz| format!("tantivy-writer{}", sz))
         .build()
         .expect("Failed to create tantivy-writer thread pool");
-    pub static ref MERGER_THREAD_POOL: ThreadPool = ThreadPoolBuilder::new()
-        .num_threads(get_num_thread(MILVUS_TANTIVY_MERGER_THREAD_NUM))
-        .thread_name(|sz| format!("tantivy-merger{}", sz))
-        .build()
-        .expect("Failed to create tantivy-writer thread pool");
+    pub static ref TOKIO_MERGER_THREAD_POOL: tokio::runtime::Runtime =
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(get_num_thread(MILVUS_TOKIO_MERGER_THREAD_NUM))
+            .thread_name("tantivy-merger")
+            .build()
+            .expect("Failed to create tantivy-writer thread pool");
+    pub static ref TOKIO_DOCSTORE_COMPRESS_RUNTIME: tokio::runtime::Runtime =
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(get_num_thread(MILVUS_TOKIO_DOCSTORE_COMPRESS_THREAD_NUM))
+            .thread_name("tantivy-docstore-compress")
+            .enable_all()
+            .build()
+            .expect("Failed to create tokio runtime");
 }
 
 fn default_num_thread() -> usize {
@@ -49,7 +59,7 @@ mod tests {
     use std::env;
 
     use super::{
-        default_num_thread, get_num_thread, MILVUS_TANTIVY_MERGER_THREAD_NUM,
+        default_num_thread, get_num_thread, MILVUS_TOKIO_MERGER_THREAD_NUM,
         MILVUS_TANTIVY_WRITER_THREAD_NUM,
     };
 
@@ -72,7 +82,7 @@ mod tests {
             let thread_num = get_num_thread(env_var);
             assert_eq!(thread_num, default_num);
         };
-        test_one(MILVUS_TANTIVY_MERGER_THREAD_NUM);
+        test_one(MILVUS_TOKIO_MERGER_THREAD_NUM);
         test_one(MILVUS_TANTIVY_WRITER_THREAD_NUM);
     }
 }

--- a/src/indexer/pool.rs
+++ b/src/indexer/pool.rs
@@ -1,7 +1,8 @@
-use lazy_static::lazy_static;
-use rayon::{ThreadPool, ThreadPoolBuilder};
 use std::str::FromStr;
 use std::{env, thread};
+
+use lazy_static::lazy_static;
+use rayon::{ThreadPool, ThreadPoolBuilder};
 
 const MILVUS_TOKIO_MERGER_THREAD_NUM: &str = "MILVUS_TANTIVY_MERGER_THREAD_NUM";
 const MILVUS_TANTIVY_WRITER_THREAD_NUM: &str = "MILVUS_TANTIVY_WRITER_THREAD_NUM";
@@ -59,8 +60,8 @@ mod tests {
     use std::env;
 
     use super::{
-        default_num_thread, get_num_thread, MILVUS_TOKIO_MERGER_THREAD_NUM,
-        MILVUS_TANTIVY_WRITER_THREAD_NUM,
+        default_num_thread, get_num_thread, MILVUS_TANTIVY_WRITER_THREAD_NUM,
+        MILVUS_TOKIO_MERGER_THREAD_NUM,
     };
 
     #[test]

--- a/src/indexer/segment_serializer.rs
+++ b/src/indexer/segment_serializer.rs
@@ -77,13 +77,13 @@ impl SegmentSerializer {
     }
 
     /// Finalize the segment serialization.
-    pub fn close(mut self) -> crate::Result<()> {
+    pub async fn close(mut self) -> crate::Result<()> {
         if let Some(fieldnorms_serializer) = self.extract_fieldnorms_serializer() {
             fieldnorms_serializer.close()?;
         }
         self.fast_field_write.terminate()?;
         self.postings_serializer.close()?;
-        self.store_writer.close()?;
+        self.store_writer.close().await?;
         Ok(())
     }
 }

--- a/src/indexer/single_segment_index_writer.rs
+++ b/src/indexer/single_segment_index_writer.rs
@@ -1,56 +1,84 @@
 use std::marker::PhantomData;
+use std::sync::Arc;
+
+use tokio::task::JoinHandle;
 
 use crate::indexer::operation::AddOperation;
 use crate::indexer::segment_updater::save_metas;
 use crate::indexer::SegmentWriter;
 use crate::schema::document::Document;
-use crate::{Directory, Index, IndexMeta, Opstamp, Segment, TantivyDocument};
+use crate::{Directory, Index, IndexMeta, Segment, TantivyDocument};
+
+use super::index_writer::error_in_index_worker_thread;
+use super::pool::TOKIO_RUNTIME;
 
 #[doc(hidden)]
 pub struct SingleSegmentIndexWriter<D: Document = TantivyDocument> {
-    segment_writer: SegmentWriter,
     segment: Segment,
-    opstamp: Opstamp,
+    tx: Arc<async_channel::Sender<D>>,
+    join_handle: JoinHandle<crate::Result<SegmentWriter>>,
     _phantom: PhantomData<D>,
 }
 
 impl<D: Document> SingleSegmentIndexWriter<D> {
     pub fn new(index: Index, mem_budget: usize) -> crate::Result<Self> {
         let segment = index.new_segment();
-        let segment_writer = SegmentWriter::for_segment(mem_budget, segment.clone())?;
+        let mut segment_writer = SegmentWriter::for_segment(mem_budget, segment.clone())?;
+        let (tx, rx) = async_channel::unbounded();
+        let join_handle = TOKIO_RUNTIME.spawn(async move {
+            let mut opstamp = 0;
+            while let Ok(document) = rx.recv().await {
+                segment_writer
+                    .add_document(AddOperation { opstamp, document })
+                    .await?;
+                opstamp += 1;
+            }
+            Ok(segment_writer)
+        });
         Ok(Self {
-            segment_writer,
             segment,
-            opstamp: 0,
+            tx: Arc::new(tx),
+            join_handle,
             _phantom: PhantomData,
         })
     }
 
-    pub fn mem_usage(&self) -> usize {
-        self.segment_writer.mem_usage()
-    }
-
     pub fn add_document(&mut self, document: D) -> crate::Result<()> {
-        let opstamp = self.opstamp;
-        self.opstamp += 1;
-        self.segment_writer
-            .add_document(AddOperation { opstamp, document })
+        let tx = self.tx.clone();
+        if TOKIO_RUNTIME
+            .block_on(async move { tx.send(document).await })
+            .is_ok()
+        {
+            return Ok(());
+        }
+        Err(error_in_index_worker_thread(
+            "An index writer encounter erros.",
+        ))
     }
 
     pub fn finalize(self) -> crate::Result<Index> {
-        let max_doc = self.segment_writer.max_doc();
-        self.segment_writer.finalize()?;
-        let segment: Segment = self.segment.with_max_doc(max_doc);
-        let index = segment.index();
-        let index_meta = IndexMeta {
-            index_settings: index.settings().clone(),
-            segments: vec![segment.meta().clone()],
-            schema: index.schema(),
-            opstamp: 0,
-            payload: None,
-        };
-        save_metas(&index_meta, index.directory())?;
-        index.directory().sync_directory()?;
-        Ok(segment.index().clone())
+        TOKIO_RUNTIME.block_on(async {
+            self.tx.close();
+            let segment_writer = self
+                .join_handle
+                .await
+                .map_err(|_| error_in_index_worker_thread("Worker thread panicked."))?
+                .map_err(|_| error_in_index_worker_thread("Worker thread failed."))?;
+
+            let max_doc = segment_writer.max_doc();
+            segment_writer.finalize().await?;
+            let segment: Segment = self.segment.with_max_doc(max_doc);
+            let index = segment.index();
+            let index_meta = IndexMeta {
+                index_settings: index.settings().clone(),
+                segments: vec![segment.meta().clone()],
+                schema: index.schema(),
+                opstamp: 0,
+                payload: None,
+            };
+            save_metas(&index_meta, index.directory())?;
+            index.directory().sync_directory()?;
+            Ok(segment.index().clone())
+        })
     }
 }

--- a/src/indexer/single_segment_index_writer.rs
+++ b/src/indexer/single_segment_index_writer.rs
@@ -3,14 +3,13 @@ use std::sync::Arc;
 
 use tokio::task::JoinHandle;
 
+use super::index_writer::error_in_index_worker_thread;
+use super::pool::TOKIO_RUNTIME;
 use crate::indexer::operation::AddOperation;
 use crate::indexer::segment_updater::save_metas;
 use crate::indexer::SegmentWriter;
 use crate::schema::document::Document;
 use crate::{Directory, Index, IndexMeta, Segment, TantivyDocument};
-
-use super::index_writer::error_in_index_worker_thread;
-use super::pool::TOKIO_RUNTIME;
 
 #[doc(hidden)]
 pub struct SingleSegmentIndexWriter<D: Document = TantivyDocument> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc(html_logo_url = "http://fulmicoton.com/tantivy-logo/tantivy-logo.png")]
 #![cfg_attr(all(feature = "unstable", test), feature(test))]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
-#![warn(missing_docs)]
 #![allow(
     clippy::len_without_is_empty,
     clippy::derive_partial_eq_without_eq,

--- a/src/postings/mod.rs
+++ b/src/postings/mod.rs
@@ -216,8 +216,8 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[test]
-    pub fn test_position_and_fieldnorm1() -> crate::Result<()> {
+    #[tokio::test]
+    pub async fn test_position_and_fieldnorm1() -> crate::Result<()> {
         let mut positions = Vec::new();
         let mut schema_builder = Schema::builder();
         let text_field = schema_builder.add_text_field("text", TEXT);
@@ -237,14 +237,14 @@ pub(crate) mod tests {
                        text_field => "d d d d a"
                     ),
                 };
-                segment_writer.add_document(op)?;
+                segment_writer.add_document(op).await?;
             }
             {
                 let op = AddOperation {
                     opstamp: 1u64,
                     document: doc!(text_field => "b a"),
                 };
-                segment_writer.add_document(op).unwrap();
+                segment_writer.add_document(op).await.unwrap();
             }
             for i in 2..1000 {
                 let mut text: String = "e ".repeat(i);
@@ -253,9 +253,9 @@ pub(crate) mod tests {
                     opstamp: 2u64,
                     document: doc!(text_field => text),
                 };
-                segment_writer.add_document(op).unwrap();
+                segment_writer.add_document(op).await.unwrap();
             }
-            segment_writer.finalize()?;
+            segment_writer.finalize().await?;
         }
         {
             let segment_reader = SegmentReader::open(&segment)?;

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -458,12 +458,13 @@ mod tests {
         assert!(DocStoreVersion::V1 < DocStoreVersion::V2);
     }
 
-    #[test]
-    fn test_store_lru_cache() -> crate::Result<()> {
+    #[tokio::test]
+    async fn test_store_lru_cache() -> crate::Result<()> {
         let directory = RamDirectory::create();
         let path = Path::new("store");
         let writer = directory.open_write(path)?;
-        let schema = write_lorem_ipsum_store(writer, 500, Compressor::default(), BLOCK_SIZE, true);
+        let schema =
+            write_lorem_ipsum_store(writer, 500, Compressor::default(), BLOCK_SIZE, true).await;
         let title = schema.get_field("title").unwrap();
         let store_file = directory.open_read(path)?;
         let store = StoreReader::open(store_file, DOCSTORE_CACHE_CAPACITY)?;


### PR DESCRIPTION
Previously, https://github.com/milvus-io/tantivy/pull/2 and https://github.com/milvus-io/tantivy/pull/3 have replaced the dedicated threads of index writer for merge worker and index write worker. This PR eliminates  the dedicated threads further for docstore compression worker.

Summary for this PR:
1. change merge rayon threadpool to tokio runtime
2. use singleton tokio runtime to replcae docstore compression threads
3. modify single segment writer to adapt the changes of some methods becoming async